### PR TITLE
Unpin task for old pinned releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,17 @@ The extension provides following tasks, all under the `deploy:pinned` namespace.
 
         deploy:pinned:unpin RELEASE_NAME=20190220192205
 
-    without the `RELEASE_NAME` environment variable, it pins the current release:
+    without the `RELEASE_NAME` environment variable, it unpins the current release:
     
         deploy:pinned:unpin
+
+4. **`unpin_old`**: Unpin old pinned releases; defaults to keeping the same number as `keep_releases`
+
+        deploy:pinned:unpin_old
+    
+    Helpful if running before cleanup
+       
+        after "deploy:pinned:unpin_old", "deploy:cleanup"
 
 These tasks can be run individually, but they're far more useful when used during the capistrano release lifecycle:
 

--- a/lib/capistrano/pinned_releases/version.rb
+++ b/lib/capistrano/pinned_releases/version.rb
@@ -2,6 +2,6 @@
 
 module Capistrano
   module PinnedReleases
-    VERSION = "1.2.0"
+    VERSION = "1.3.0"
   end
 end

--- a/lib/capistrano/tasks/deploy.rb
+++ b/lib/capistrano/tasks/deploy.rb
@@ -68,6 +68,7 @@ namespace :deploy do
           releases_to_unpin = pinned_releases.sort.take(take_count)
 
           releases_to_unpin.each do |pin_name|
+            info t(:unpinning_releases, host: host.to_s, release_name: pin_name)
             execute :rm, "-f", pin_name
           end
         end

--- a/lib/capistrano/tasks/deploy.rb
+++ b/lib/capistrano/tasks/deploy.rb
@@ -65,7 +65,7 @@ namespace :deploy do
 
         if pinned_releases.count > keep_releases
           take_count = pinned_releases.count - keep_releases
-          releases_to_unpin = pinned_releases.take(take_count)
+          releases_to_unpin = pinned_releases.sort.take(take_count)
 
           releases_to_unpin.each do |pin_name|
             execute :rm, "-f", pin_name

--- a/lib/capistrano/tasks/deploy.rb
+++ b/lib/capistrano/tasks/deploy.rb
@@ -56,6 +56,9 @@ namespace :deploy do
       end
     end
 
+    # rubocop:disable Metrics/LineLength
+    desc "Unpin all except the most recent releases: 'cap production deploy:pin:unpin_old'"
+    # rubocop:enable Metrics/LineLength
     task unpin_old: "deploy:check" do
       on release_roles :all do
         pinned_releases_directory = deploy_path.join("pinned_releases")

--- a/lib/capistrano/tasks/deploy.rb
+++ b/lib/capistrano/tasks/deploy.rb
@@ -56,6 +56,24 @@ namespace :deploy do
       end
     end
 
+    task unpin_old: "deploy:check" do
+      on release_roles :all do
+        pinned_releases_directory = deploy_path.join("pinned_releases")
+        pinned_releases = capture :ls, pinned_releases_directory
+
+        keep_releases = fetch(:keep_releases)
+
+        if pinned_releases.count > keep_releases
+          take_count = pinned_releases.count - keep_releases
+          releases_to_unpin = pinned_releases.take(take_count)
+
+          releases_to_unpin.each do |pin_name|
+            execute :rm, "-f", pin_name
+          end
+        end
+      end
+    end
+
     desc "List all currently pinned releases"
     task list: "deploy:check" do
       on release_roles :all do

--- a/lib/capistrano/tasks/deploy.rb
+++ b/lib/capistrano/tasks/deploy.rb
@@ -88,7 +88,6 @@ namespace :deploy do
   end
 
   desc "Clean up old releases"
-  Rake::Task["deploy:cleanup"].clear_actions if Rake::Task.include?("deploy:cleanup")
   task cleanup: "check:directories" do
     on release_roles :all do |host|
       releases = capture(:ls, "-x", releases_path).split

--- a/lib/capistrano/tasks/deploy.rb
+++ b/lib/capistrano/tasks/deploy.rb
@@ -69,7 +69,7 @@ namespace :deploy do
           releases_to_unpin = pinned_releases.take(take_count)
 
           releases_to_unpin.each do |release_name|
-            info t(:unpinning_releases, host: host.to_s, release_name: release_name)
+            info t(:unpinning_release, host: host.to_s, release_name: release_name)
             pin_name = pinned_releases_directory.join(release_name)
             execute :rm, "-f", pin_name
           end

--- a/lib/capistrano/tasks/deploy.rb
+++ b/lib/capistrano/tasks/deploy.rb
@@ -68,8 +68,9 @@ namespace :deploy do
           take_count = pinned_releases.count - keep_releases
           releases_to_unpin = pinned_releases.take(take_count)
 
-          releases_to_unpin.each do |pin_name|
-            info t(:unpinning_releases, host: host.to_s, release_name: pin_name)
+          releases_to_unpin.each do |release_name|
+            info t(:unpinning_releases, host: host.to_s, release_name: release_name)
+            pin_name = pinned_releases_directory.join(release_name)
             execute :rm, "-f", pin_name
           end
         end

--- a/lib/capistrano/tasks/deploy.rb
+++ b/lib/capistrano/tasks/deploy.rb
@@ -88,7 +88,7 @@ namespace :deploy do
   end
 
   desc "Clean up old releases"
-  Rake::Task["deploy:cleanup"].clear_actions
+  Rake::Task["deploy:cleanup"].clear_actions if Rake::Task.include?("deploy:cleanup")
   task cleanup: "check:directories" do
     on release_roles :all do |host|
       releases = capture(:ls, "-x", releases_path).split

--- a/lib/capistrano/tasks/deploy.rb
+++ b/lib/capistrano/tasks/deploy.rb
@@ -59,13 +59,13 @@ namespace :deploy do
     task unpin_old: "deploy:check" do
       on release_roles :all do
         pinned_releases_directory = deploy_path.join("pinned_releases")
-        pinned_releases = capture :ls, pinned_releases_directory
+        pinned_releases = capture(:ls, pinned_releases_directory).split(/\s+/).sort
 
         keep_releases = fetch(:keep_releases)
 
         if pinned_releases.count > keep_releases
           take_count = pinned_releases.count - keep_releases
-          releases_to_unpin = pinned_releases.sort.take(take_count)
+          releases_to_unpin = pinned_releases.take(take_count)
 
           releases_to_unpin.each do |pin_name|
             info t(:unpinning_releases, host: host.to_s, release_name: pin_name)

--- a/lib/capistrano/tasks/deploy.rb
+++ b/lib/capistrano/tasks/deploy.rb
@@ -12,7 +12,7 @@ namespace :deploy do
 
   namespace :pinned do
     # rubocop:disable Metrics/LineLength
-    desc "Pin a given release: 'cap production deploy:pin:release RELEASE_NAME=20190220192205', without RELEASE_NAME pins the current release"
+    desc "Pin a given release: 'cap production deploy:pinned:pin RELEASE_NAME=20190220192205', without RELEASE_NAME pins the current release"
     # rubocop:enable Metrics/LineLength
     task pin: "deploy:check" do
       on release_roles :all do
@@ -36,7 +36,7 @@ namespace :deploy do
     end
 
     # rubocop:disable Metrics/LineLength
-    desc "Unpin a given release: 'cap production deploy:pin:remove RELEASE_NAME=20190220192205', without RELEASE_NAME unpins the current release"
+    desc "Unpin a given release: 'cap production deploy:pinned:unpin RELEASE_NAME=20190220192205', without RELEASE_NAME unpins the current release"
     # rubocop:enable Metrics/LineLength
     task unpin: "deploy:check" do
       on release_roles :all do
@@ -56,15 +56,13 @@ namespace :deploy do
       end
     end
 
-    # rubocop:disable Metrics/LineLength
-    desc "Unpin all except the most recent releases: 'cap production deploy:pin:unpin_old'"
-    # rubocop:enable Metrics/LineLength
+    desc "Unpin all except the most recent releases: 'cap production deploy:pinned:unpin_old'"
     task unpin_old: "deploy:check" do
       on release_roles :all do
         pinned_releases_directory = deploy_path.join("pinned_releases")
         pinned_releases = capture(:ls, pinned_releases_directory).split(/\s+/).sort
 
-        keep_releases = fetch(:keep_releases)
+        keep_releases = fetch(:keep_pinned_releases, fetch(:keep_releases))
 
         if pinned_releases.count > keep_releases
           take_count = pinned_releases.count - keep_releases


### PR DESCRIPTION
Within reason, some users may want to auto unpin the oldest releases for cleanup. Otherwise, servers may accumulate a large number of pinned releases
without the dev team realizing it.